### PR TITLE
Focus on the what field when creating action

### DIFF
--- a/app/components/action/action-form.tsx
+++ b/app/components/action/action-form.tsx
@@ -21,6 +21,7 @@ export default function ActionForm({ action, onSubmit, onCancel } : props) {
             <div className="flex flex-col mb-2">
                 <label className="block" htmlFor="newActionWhat">What are we trying?</label>
                 <input
+                    autoFocus
                     className="block"
                     type="text"
                     id="newActionWhat"

--- a/cypress/e2e/everything.cy.js
+++ b/cypress/e2e/everything.cy.js
@@ -247,6 +247,12 @@ describe('Ongoing Incident: Managing Actions', () => {
     action.within(el => el.get('input[data-test="action__is-mitigating"')).should('not.be.checked')
   })
 
+  it('allows you to start typing the what without clicking on the field', () => {
+    getDataTest('actions__active__add_action').click()
+
+    getDataTest('new-action__what').should('be.focused')
+  })
+
   it('lets you edit the text of an active action', () => {
     const what = 'old what'
     addActionToIncident({ what })


### PR DESCRIPTION
So you can start typing immediately without needing to click the field, keeping it smooth when using the UI as a commander. :)