### PR TITLE
Disable notifications when API not available

### DIFF
--- a/app/components/action/action.tsx
+++ b/app/components/action/action.tsx
@@ -123,7 +123,7 @@ export default function Action({action}: props) {
                             durationInMinutes={action.timerDurationInMinutes}
                             label={action.what}
                             onCompleted={(id, label)=> {
-                                if (notificationPermission && label) {
+                                if (notificationPermission && label && typeof Notification !== 'undefined') {
                                     new Notification(label) // eslint-disable-line no-new
                                 }
                             }}

--- a/app/components/ongoing-incident/ongoing-incident.tsx
+++ b/app/components/ongoing-incident/ongoing-incident.tsx
@@ -185,7 +185,7 @@ export default function OngoingIncident() {
             let ydocEvents = setupMultiplayer(dispatch)
             setDispatcher(()=>{return multiplayerDispatch.bind(null, ydocEvents)})
         }
-        if (Notification.permission == 'granted') {
+        if (typeof Notification !== 'undefined' && Notification.permission == 'granted') {
             Notification.requestPermission().then((newPermission)=>{
                 setNotificationPermission(newPermission == 'granted')
             });
@@ -198,7 +198,7 @@ export default function OngoingIncident() {
 
     const [notificationPermission, setNotificationPermission] = useState(false)
     useEffect(() => {
-        setNotificationPermission(Notification.permission == 'granted')
+        setNotificationPermission(typeof Notification !== 'undefined' && Notification.permission == 'granted')
     }, [])
     const toggleNotifications = (event: any) => {
         if (notificationPermission) {
@@ -228,7 +228,7 @@ export default function OngoingIncident() {
         <IncidentDispatchContext.Provider value={dispatcher}>
             {/*<button id="debug-create-incident">DEBUG: Create Incident</button>*/}
 
-            <header>
+            <header hidden={typeof Notification === 'undefined'}>
                 <Button onClick={toggleNotifications}>
                     {
                         notificationPermission


### PR DESCRIPTION
This API is not available on mobile safari and was crashing the page. I just hacked together the solution because I wanted it to work but it needs to be cleaned into something coherent that isn't a load of conditionals all over.

Spontaneously, I think making a new object that wraps the Notification API makes sense (or to find some react component that does it), but I'll create another ticket to deal with that refactoring. :)

Fixes #122.

---

Also, very happy with how easy it is to debug Mobile Safari using normal Safari :D